### PR TITLE
[Pronto] Criar API de conversas de bot

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,3 +179,93 @@
 
 - Plano não encontrado:
   - Status de comunicação devolvido será: **404**
+
+### Iniciar conversa de Bot
+
+#### Descrição
+
+<p align="justify">A API de conversa de Bot permite registrar o início de uma conversa que o bot fez com um cliente.</p>
+
+#### Parametros necessarios
+
+- Token do Bot no nosso sistema [bot][token]
+- Identificador da conversa no sistema externo [bot_chat][external_token]
+- Plataforma onde ocorreu a conversa [bot_chat][platform]
+- Tempo de início da conversa [bot_chat][start_time]
+- **Todos os dados devem ser enviados como um JSON**
+- **Exemplo:**
+
+```json
+{
+  "bot": {
+    "token": "M5KJHU"
+  },
+  "bot_chat": {
+    "external_token": "skdpofmp3201qjoifjpkp",
+    "platform": "Whatsapp",
+    "start_time": "2020-07-07 18:46:36"
+  }
+}
+```
+
+#### Verbo HTTP
+
+- **POST**
+- Os dados devem ser enviados para seguinte rota:
+  - **/api/v1/bot_chats**
+
+#### Parametros devolvidos
+
+- Status da comunicação 200
+- **Todos os dados serão enviados como um JSON**
+
+#### Possiveis erros
+
+- Bot não encontrado por Token:
+  - Status de comunicação devolvido será: **404**
+- Já existe uma conversa de bot cadastrada com o mesmo identificador externo:
+  - Status de comunicação devolvido será: **422**
+
+### Encerrar conversa de Bot
+
+#### Descrição
+
+<p align="justify">Complementando a API de conversa de Bot, criamos uma action que recebe os dados da conversa e quantidade de mensagens, assim encerrando uma conversa do bot e cadastrando todos os dados para controle do sistema. </p>
+
+#### Parametros necessarios
+
+- Identificador da conversa no sistema externo [bot_chat][external_token]
+- Tempo que a conversa foi encerrada [bot_chat][end_time]
+- Quantidade de mensagens trocadas [bot_chat][message_count]
+- **Todos os dados devem ser enviados como um JSON**
+- **Exemplo:**
+
+```json
+{
+  "bot_chat": {
+    "external_token": "dasd",
+    "end_time": "2020-07-07 19:46:36",
+    "message_count": 42
+  }
+}
+```
+
+#### Verbo HTTP
+
+- **POST**
+- Os dados devem ser enviados para seguinte rota:
+  - **/api/v1/bot_chats/finish**
+
+#### Parametros devolvidos
+
+- Status da comunicação 200
+- **Todos os dados serão enviados como um JSON**
+
+#### Possiveis erros
+
+- Status de comunicação devolvido será: **404**
+
+  - Conversa não encontrada por Token
+
+- Status de comunicação devolvido será: **422**
+  - Tempo de termino(end_time) ocorreu antes do tempo de inicio da conversa(start_time)

--- a/app/controllers/api/v1/bot_chats_controller.rb
+++ b/app/controllers/api/v1/bot_chats_controller.rb
@@ -3,14 +3,14 @@ class Api::V1::BotChatsController < Api::V1::ApiController
     bot = Bot.find_by!(token: params[:bot][:token])
     bot.chats.create!(create_bot_chat_params)
 
-    render json: {}, status: :no_content
+    head :no_content
   end
 
   def finish
     bot_chat = BotChat.find_by!(external_token: params[:bot_chat][:external_token])
     bot_chat.update!(finish_bot_chat_params)
 
-    render json: {}, status: :no_content
+    head :no_content
   end
 
   private

--- a/app/controllers/api/v1/bot_chats_controller.rb
+++ b/app/controllers/api/v1/bot_chats_controller.rb
@@ -1,14 +1,25 @@
 class Api::V1::BotChatsController < Api::V1::ApiController
   def create
     bot = Bot.find_by!(token: params[:bot][:token])
-    bot.chats.create!(bot_chat_params)
+    bot.chats.create!(create_bot_chat_params)
+
+    render json: {}, status: :ok
+  end
+
+  def finish
+    bot_chat = BotChat.find_by!(external_token: params[:bot_chat][:external_token])
+    bot_chat.update!(finish_bot_chat_params)
 
     render json: {}, status: :ok
   end
 
   private
 
-  def bot_chat_params
+  def create_bot_chat_params
     params.require(:bot_chat).permit(:external_token, :platform, :start_time)
+  end
+
+  def finish_bot_chat_params
+    params.require(:bot_chat).permit(:end_time, :message_count)
   end
 end

--- a/app/controllers/api/v1/bot_chats_controller.rb
+++ b/app/controllers/api/v1/bot_chats_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::BotChatsController < Api::V1::ApiController
+  def create
+    bot = Bot.find_by!(token: params[:bot][:token])
+    bot.chats.create!(bot_chat_params)
+
+    render json: {}, status: :ok
+  end
+
+  private
+
+  def bot_chat_params
+    params.require(:bot_chat).permit(:external_token, :platform, :start_time)
+  end
+end

--- a/app/controllers/api/v1/bot_chats_controller.rb
+++ b/app/controllers/api/v1/bot_chats_controller.rb
@@ -3,14 +3,14 @@ class Api::V1::BotChatsController < Api::V1::ApiController
     bot = Bot.find_by!(token: params[:bot][:token])
     bot.chats.create!(create_bot_chat_params)
 
-    render json: {}, status: :ok
+    render json: {}, status: :no_content
   end
 
   def finish
     bot_chat = BotChat.find_by!(external_token: params[:bot_chat][:external_token])
     bot_chat.update!(finish_bot_chat_params)
 
-    render json: {}, status: :ok
+    render json: {}, status: :no_content
   end
 
   private

--- a/app/controllers/api/v1/purchase_cancellations_controller.rb
+++ b/app/controllers/api/v1/purchase_cancellations_controller.rb
@@ -3,6 +3,6 @@ class Api::V1::PurchaseCancellationsController < Api::V1::ApiController
     purchase = Purchase.find_by!(token: params[:purchase][:token])
     PurchaseCancellation.create!(purchase: purchase, reason: params[:reason])
 
-    render json: {}, status: :no_content
+    head :no_content
   end
 end

--- a/app/controllers/api/v1/purchase_cancellations_controller.rb
+++ b/app/controllers/api/v1/purchase_cancellations_controller.rb
@@ -3,6 +3,6 @@ class Api::V1::PurchaseCancellationsController < Api::V1::ApiController
     purchase = Purchase.find_by!(token: params[:purchase][:token])
     PurchaseCancellation.create!(purchase: purchase, reason: params[:reason])
 
-    render json: {}, status: :ok
+    render json: {}, status: :no_content
   end
 end

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -1,7 +1,9 @@
 class Bot < ApplicationRecord
   belongs_to :company
   belongs_to :purchase
+
   enum status: { active: 0, canceled: 5, blocked: 10 }
+
   validates :token, uniqueness: true
   before_create :generate_token
 

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -1,6 +1,7 @@
 class Bot < ApplicationRecord
   belongs_to :company
   belongs_to :purchase
+  has_many :chats, class_name: 'BotChat', dependent: :restrict_with_error
 
   enum status: { active: 0, canceled: 5, blocked: 10 }
 

--- a/app/models/bot_chat.rb
+++ b/app/models/bot_chat.rb
@@ -1,0 +1,5 @@
+class BotChat < ApplicationRecord
+  belongs_to :bot
+
+  validates :external_token, :start_time, :platform, :bot, presence: true
+end

--- a/app/models/bot_chat.rb
+++ b/app/models/bot_chat.rb
@@ -3,4 +3,29 @@ class BotChat < ApplicationRecord
 
   validates :external_token, :start_time, :platform, :bot, presence: true
   validates :external_token, uniqueness: true
+  validate :whether_it_starts_in_the_past
+  validate :whether_it_ends_after_it_starts
+
+  private
+
+  def whether_it_starts_in_the_past
+    return if start_time_in_the_past?
+
+    errors.add :start_time, :in_the_future
+  end
+
+  def start_time_in_the_past?
+    start_time && start_time <= Time.zone.now
+  end
+
+  def whether_it_ends_after_it_starts
+    return unless start_time && end_time
+    return if end_time_after_start_time?
+
+    errors.add :end_time, :before_start_time
+  end
+
+  def end_time_after_start_time?
+    end_time > start_time
+  end
 end

--- a/app/models/bot_chat.rb
+++ b/app/models/bot_chat.rb
@@ -2,4 +2,5 @@ class BotChat < ApplicationRecord
   belongs_to :bot
 
   validates :external_token, :start_time, :platform, :bot, presence: true
+  validates :external_token, uniqueness: true
 end

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -2,7 +2,8 @@ class Company < ApplicationRecord
   has_many :bots, dependent: :destroy
 
   validates :name, :address, :corporate_name, :cnpj, presence: true
-  validates :cnpj, :token, uniqueness: true
+  validates :token, uniqueness: true
+  validates :cnpj, uniqueness: true, case_sensitive: false
   validates :cnpj, format: { with: %r{\A^\d{2,3}\.\d{3}\.\d{3}/\d{4}-\d{2}$\z} }
   validate :cnpj_must_be_valid
 

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,5 +1,6 @@
 class Company < ApplicationRecord
   has_many :bots, dependent: :destroy
+
   validates :name, :address, :corporate_name, :cnpj, presence: true
   validates :cnpj, :token, uniqueness: true
   validates :cnpj, format: { with: %r{\A^\d{2,3}\.\d{3}\.\d{3}/\d{4}-\d{2}$\z} }

--- a/config/locales/pt-BR/models/bot.yml
+++ b/config/locales/pt-BR/models/bot.yml
@@ -4,6 +4,7 @@ pt-BR:
     models:
       bot:
         one: Bot
+        other: Bots
 
     attributes:
       attr_defaults: &attr_defaults
@@ -11,9 +12,11 @@ pt-BR:
         created_at: Criado
         updated_at: Alterado
         deleted_at: Excluído
-        token: Token
+
       bot:
         <<: *attr_defaults
+        token: Token
+
       bot/status:
         active: Ativo
         canceled: Cancelado

--- a/config/locales/pt-BR/models/bot_chat.yml
+++ b/config/locales/pt-BR/models/bot_chat.yml
@@ -1,0 +1,31 @@
+---
+pt-BR:
+  activerecord:
+    models:
+      bot_chat:
+        one: Conversa de Bot
+        other: Conversas de Bot
+
+    attributes:
+      attr_defaults: &attr_defaults
+        id: ID
+        created_at: Criado
+        updated_at: Alterado
+        deleted_at: Excluído
+
+      bot_chat:
+        <<: *attr_defaults
+        start_time: Início da Conversa
+        end_time: Fim da Conversa
+        platform: Plataforma
+        external_token: Token externo
+        message_count: Número de mensagens
+
+    errors:
+      models:
+        bot_chat:
+          attributes:
+            start_time:
+              in_the_future: não pode ser no futuro.
+            end_time:
+              before_start_time: deve ser depois do início da conversa.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
 
   root to: 'home#index'
-  resources :bots, only: %i[create, index]
+  resources :bots, only: %i[create index]
   resources :plans, only: %i[index show new create edit update]
   resources :purchase_cancellations, only: %i[index show] do
     post :approve, on: :member
@@ -15,6 +15,7 @@ Rails.application.routes.draw do
       resources :plans, only: %i[index show]
       resources :purchases, only: %i[create]
       resources :purchase_cancellations, only: %i[create]
+      resources :bot_chats, only: %i[create]
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,7 +15,9 @@ Rails.application.routes.draw do
       resources :plans, only: %i[index show]
       resources :purchases, only: %i[create]
       resources :purchase_cancellations, only: %i[create]
-      resources :bot_chats, only: %i[create]
+      resources :bot_chats, only: %i[create] do
+        post :finish, on: :collection
+      end
     end
   end
 end

--- a/db/migrate/20200707214636_create_bot_chats.rb
+++ b/db/migrate/20200707214636_create_bot_chats.rb
@@ -1,0 +1,16 @@
+class CreateBotChats < ActiveRecord::Migration[6.0]
+  def change
+    create_table :bot_chats do |t|
+      t.datetime :start_time
+      t.datetime :end_time
+      t.string :platform
+      t.string :external_token
+      t.references :bot, null: false, foreign_key: true
+      t.integer :message_count
+
+      t.timestamps
+    end
+
+    add_index :bot_chats, :external_token, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,20 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_07_193518) do
+ActiveRecord::Schema.define(version: 2020_07_07_214636) do
+
+  create_table "bot_chats", force: :cascade do |t|
+    t.datetime "start_time"
+    t.datetime "end_time"
+    t.string "platform"
+    t.string "external_token"
+    t.integer "bot_id", null: false
+    t.integer "message_count"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["bot_id"], name: "index_bot_chats_on_bot_id"
+    t.index ["external_token"], name: "index_bot_chats_on_external_token", unique: true
+  end
 
   create_table "bots", force: :cascade do |t|
     t.integer "company_id", null: false
@@ -96,6 +109,7 @@ ActiveRecord::Schema.define(version: 2020_07_07_193518) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "bot_chats", "bots"
   add_foreign_key "bots", "companies"
   add_foreign_key "bots", "purchases"
   add_foreign_key "plan_prices", "plans"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -8,3 +8,6 @@ FactoryBot.create_list :company, 5
 
 FactoryBot.create_list :purchase, 5
 FactoryBot.create_list :purchase_cancellation, 5
+
+FactoryBot.create_list :bot, 3
+FactoryBot.create_list :bot_chat, 5

--- a/spec/factories/bot_chats.rb
+++ b/spec/factories/bot_chats.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :bot_chat do
+    bot
+    start_time { "2020-07-07 18:46:36" }
+    end_time { "2020-07-07 18:46:36" }
+    platform { "MyString" }
+    external_token { "MyString" }
+    message_count { 1 }
+  end
+end

--- a/spec/factories/bot_chats.rb
+++ b/spec/factories/bot_chats.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     start_time { "2020-07-07 18:46:36" }
     end_time { "2020-07-07 18:46:36" }
     platform { "MyString" }
-    external_token { "MyString" }
+    external_token { Faker::Alphanumeric.unique.alphanumeric(number: 15) }
     message_count { 1 }
   end
 end

--- a/spec/factories/bot_chats.rb
+++ b/spec/factories/bot_chats.rb
@@ -1,10 +1,13 @@
 FactoryBot.define do
   factory :bot_chat do
     bot
-    start_time { "2020-07-07 18:46:36" }
-    end_time { "2020-07-07 18:46:36" }
-    platform { "MyString" }
+    start_time { Time.zone.now - 1.hour }
+    platform { 'MyString' }
     external_token { Faker::Alphanumeric.unique.alphanumeric(number: 15) }
-    message_count { 1 }
+
+    trait :end_conversation do
+      end_time { Time.zone.now + 1.hour }
+      message_count { 1 }
+    end
   end
 end

--- a/spec/models/bot_chat_spec.rb
+++ b/spec/models/bot_chat_spec.rb
@@ -17,4 +17,23 @@ RSpec.describe BotChat, type: :model do
     expect(subject).to validate_presence_of(:platform)
     expect(subject).to validate_presence_of(:bot)
   end
+
+  context 'start_time' do
+    it 'must be in the past' do
+      subject.start_time = 1.hour.from_now
+
+      expect(subject).to_not be_valid
+      expect(subject.errors[:start_time]).to include('não pode ser no futuro.')
+    end
+  end
+
+  context 'end_time' do
+    it 'must be after start_time' do
+      subject.start_time = 1.hour.ago
+      subject.end_time = 2.hours.ago
+
+      expect(subject).to_not be_valid
+      expect(subject.errors[:end_time]).to include('deve ser depois do início da conversa.')
+    end
+  end
 end

--- a/spec/models/bot_chat_spec.rb
+++ b/spec/models/bot_chat_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe BotChat, type: :model do
     expect(subject).to validate_presence_of(:bot)
   end
 
+  it 'validates unique attributes' do
+    expect(subject).to validate_uniqueness_of(:external_token)
+  end
+
   context 'start_time' do
     it 'must be in the past' do
       subject.start_time = 1.hour.from_now

--- a/spec/models/bot_chat_spec.rb
+++ b/spec/models/bot_chat_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe BotChat, type: :model do
+  subject { create :bot_chat }
+
+  it 'has relations' do
+    expect(subject).to belong_to(:bot)
+  end
+
+  it 'is valid with valid attributes' do
+    expect(subject).to be_valid
+  end
+
+  it 'validates mandatory attributes' do
+    expect(subject).to validate_presence_of(:external_token)
+    expect(subject).to validate_presence_of(:start_time)
+    expect(subject).to validate_presence_of(:platform)
+    expect(subject).to validate_presence_of(:bot)
+  end
+end

--- a/spec/models/bot_spec.rb
+++ b/spec/models/bot_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Bot, type: :model do
   it 'has relations' do
     expect(subject).to belong_to(:company)
     expect(subject).to belong_to(:purchase)
+    expect(subject).to have_many(:chats).class_name('BotChat')
   end
 
   it 'is valid with valid attributes' do

--- a/spec/models/bot_spec.rb
+++ b/spec/models/bot_spec.rb
@@ -13,12 +13,16 @@ RSpec.describe Bot, type: :model do
     expect(subject).to be_valid
   end
 
+  it 'validates unique attributes' do
+    expect(subject).to validate_uniqueness_of(:token)
+  end
+
   context 'token' do
     it 'should generate a token on create' do
       expect(subject.token).to match RegexSupport::VALID_TOKEN_REGEX
     end
 
-    it 'token must be unique' do
+    it 'generates a unique token' do
       bot = build(:bot)
       allow(SecureRandom).to receive(:alphanumeric).and_return(subject.token, 'ABC123')
       bot.save

--- a/spec/models/bot_spec.rb
+++ b/spec/models/bot_spec.rb
@@ -1,13 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe Bot, type: :model do
-  it 'token must be unique' do
-    first_bot = create(:bot, token: 'ABC123')
-    second_bot = build(:bot)
-    allow(SecureRandom).to receive(:alphanumeric).and_return(first_bot.token,
-                                                             'AAA000')
-    second_bot.save
+  subject { create :bot }
 
-    expect(first_bot.token).not_to eq(second_bot.token)
+  it 'has relations' do
+    expect(subject).to belong_to(:company)
+    expect(subject).to belong_to(:purchase)
+  end
+
+  it 'is valid with valid attributes' do
+    expect(subject).to be_valid
+  end
+
+  context 'token' do
+    it 'should generate a token on create' do
+      expect(subject.token).to match RegexSupport::VALID_TOKEN_REGEX
+    end
+
+    it 'token must be unique' do
+      bot = build(:bot)
+      allow(SecureRandom).to receive(:alphanumeric).and_return(subject.token, 'ABC123')
+      bot.save
+      expect(bot.token).not_to eq(subject.token)
+    end
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -14,12 +14,17 @@ RSpec.describe Company, type: :model do
     expect(subject).to validate_presence_of(:cnpj)
   end
 
+  it 'validates unique attributes' do
+    expect(subject).to validate_uniqueness_of(:cnpj).case_insensitive
+    expect(subject).to validate_uniqueness_of(:token)
+  end
+
   context 'token' do
     it 'should generate a token on create' do
       expect(subject.token).to match RegexSupport::VALID_TOKEN_REGEX
     end
 
-    it 'token must be unique' do
+    it 'generates a unique token' do
       company = build(:company)
       allow(SecureRandom).to receive(:alphanumeric).and_return(subject.token, 'ABC123')
       company.save
@@ -40,13 +45,6 @@ RSpec.describe Company, type: :model do
 
       expect(subject).to_not be_valid
       expect(subject.errors[:cnpj]).to include('não é válido')
-    end
-
-    it 'must be unique' do
-      create(:company, cnpj: '22.927.293/0001-90')
-      company = build(:company, cnpj: '22.927.293/0001-90')
-      expect(company).to_not be_valid
-      expect(company.errors[:cnpj]).to include('já está em uso')
     end
   end
 end

--- a/spec/models/plan_price_spec.rb
+++ b/spec/models/plan_price_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe PlanPrice, type: :model do
     expect(subject).to be_valid
   end
 
-  it 'validates attributes' do
+  it 'validates mandatory attributes' do
     expect(subject).to validate_presence_of(:value)
   end
 end

--- a/spec/models/plan_spec.rb
+++ b/spec/models/plan_spec.rb
@@ -23,12 +23,8 @@ RSpec.describe Plan, type: :model do
     expect(subject).to validate_presence_of(:extra_chat_price)
   end
 
-  it 'name must be unique' do
-    subject.save
-    new_plan = described_class.new(name: subject.name)
-
-    expect(new_plan).not_to be_valid
-    expect(new_plan.errors[:name]).to include('já está em uso')
+  it 'validates unique attributes' do
+    expect(subject).to validate_uniqueness_of(:name)
   end
 
   it 'should create a plan_price before saving' do

--- a/spec/requests/botchat_api_spec.rb
+++ b/spec/requests/botchat_api_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe 'Botchat tracking messages' do
-  context 'POST /api/v1/bot_chat/start' do
+  context 'POST /api/v1/bot_chats' do
     it 'should create a bot chat' do
       bot = create(:bot)
       current_time = Time.now.iso8601
@@ -21,7 +21,7 @@ describe 'Botchat tracking messages' do
     it 'should return not found for an invalid bot token' do
       current_time = Time.now.iso8601
       post api_v1_bot_chats_path,
-           params: { bot: { token: "4D8F99" },
+           params: { bot: { token: '4D8F99' },
                      bot_chat: { external_token: 'ABC123',
                                  platform: 'Facebook',
                                  start_time: current_time } }
@@ -37,6 +37,45 @@ describe 'Botchat tracking messages' do
                      bot_chat: { external_token: bot_chat.external_token,
                                  platform: 'Facebook',
                                  start_time: current_time } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+
+  context 'POST /api/v1/bot_chat/finish' do
+    it 'should finish a conversation' do
+      bot_chat = create(:bot_chat, start_time: Time.zone.now - 1.minute)
+      current_time = Time.zone.now.iso8601
+
+      post finish_api_v1_bot_chats_path,
+           params: { bot_chat: { external_token: bot_chat.external_token,
+                                 end_time: current_time,
+                                 message_count: 42 } }
+
+      bot_chat.reload
+      expect(response).to have_http_status(:ok)
+      expect(bot_chat.end_time).to eq(current_time)
+      expect(bot_chat.message_count).to eq(42)
+    end
+
+    it 'should return not found for an invalid external token' do
+      current_time = Time.now.iso8601
+      post finish_api_v1_bot_chats_path,
+           params: { bot_chat: { external_token: 'dadadasdeaxcacada',
+                                 end_time: current_time,
+                                 message_count: 42 } }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'should return unprocessable entity if end_time before start_time' do
+      bot_chat = create(:bot_chat, start_time: Time.zone.now)
+      bad_time = Time.zone.now - 1.minute
+
+      post finish_api_v1_bot_chats_path,
+           params: { bot_chat: { external_token: bot_chat.external_token,
+                                 end_time: bad_time.iso8601,
+                                 message_count: 42 } }
 
       expect(response).to have_http_status(:unprocessable_entity)
     end

--- a/spec/requests/botchat_api_spec.rb
+++ b/spec/requests/botchat_api_spec.rb
@@ -11,7 +11,7 @@ describe 'Botchat tracking messages' do
                                  platform: 'Facebook',
                                  start_time: current_time } }
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:no_content)
       expect(bot.chats.count).to eq(1)
       expect(bot.chats.first.external_token).to eq('ABC123')
       expect(bot.chats.first.platform).to eq('Facebook')
@@ -53,7 +53,7 @@ describe 'Botchat tracking messages' do
                                  message_count: 42 } }
 
       bot_chat.reload
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:no_content)
       expect(bot_chat.end_time).to eq(current_time)
       expect(bot_chat.message_count).to eq(42)
     end

--- a/spec/requests/botchat_api_spec.rb
+++ b/spec/requests/botchat_api_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+describe 'Botchat tracking messages' do
+  context 'POST /api/v1/bot_chat/start' do
+    it 'should create a bot chat' do
+      bot = create(:bot)
+      current_time = Time.now.iso8601
+      post api_v1_bot_chats_path,
+           params: { bot: { token: bot.token },
+                     bot_chat: { external_token: 'ABC123',
+                                 platform: 'Facebook',
+                                 start_time: current_time } }
+
+      expect(response).to have_http_status(:ok)
+      expect(bot.chats.count).to eq(1)
+      expect(bot.chats.first.external_token).to eq('ABC123')
+      expect(bot.chats.first.platform).to eq('Facebook')
+      expect(bot.chats.first.start_time).to eq(current_time)
+    end
+
+    it 'should return not found for an invalid bot token' do
+      current_time = Time.now.iso8601
+      post api_v1_bot_chats_path,
+           params: { bot: { token: "4D8F99" },
+                     bot_chat: { external_token: 'ABC123',
+                                 platform: 'Facebook',
+                                 start_time: current_time } }
+
+      expect(response).to have_http_status(:not_found)
+    end
+
+    it 'should return an unprocessable entity if external token is already used' do
+      bot_chat = create(:bot_chat)
+      current_time = Time.now.iso8601
+      post api_v1_bot_chats_path,
+           params: { bot: { token: bot_chat.bot.token },
+                     bot_chat: { external_token: bot_chat.external_token,
+                                 platform: 'Facebook',
+                                 start_time: current_time } }
+
+      expect(response).to have_http_status(:unprocessable_entity)
+    end
+  end
+end

--- a/spec/requests/purchase_cancellations_api_spec.rb
+++ b/spec/requests/purchase_cancellations_api_spec.rb
@@ -34,7 +34,7 @@ describe 'Purchase cancellation requests' do
       expect(json_response[:error]).to eq 'Compra não encontrada(o).'
     end
 
-    it 'should return bad request if threre is an open cancellation request' do
+    it 'should return unprocessable entity if threre is an open cancellation request' do
       purchase = create(:purchase)
       create(:purchase_cancellation, purchase: purchase)
 

--- a/spec/requests/purchase_cancellations_api_spec.rb
+++ b/spec/requests/purchase_cancellations_api_spec.rb
@@ -8,7 +8,7 @@ describe 'Purchase cancellation requests' do
       post api_v1_purchase_cancellations_path,
            params: { purchase: { token: purchase.token } }
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:no_content)
       expect(purchase.cancellation_requests.count).to eq(1)
     end
 
@@ -19,7 +19,7 @@ describe 'Purchase cancellation requests' do
            params: { purchase: { token: purchase.token },
                      reason: 'Não preciso mais deste serviço.' }
 
-      expect(response).to have_http_status(:ok)
+      expect(response).to have_http_status(:no_content)
       expect(purchase.cancellation_requests.count).to eq(1)
       expect(purchase.cancellation_requests.first.reason).to eq('Não preciso mais deste serviço.')
     end


### PR DESCRIPTION
Issue: https://github.com/TreinaDev/gestao_interna/issues/9

## Motivação

Neste PR adicionamos duas rotas novas à API:
- Uma que registra o início de uma conversa do bot.
- Outra que registra o termino da conversa, com o número de mensagems enviadas. 


## Comentários

Validamos que o início da conversa deve ser no passado, e que o início deve ser antes do termino.