### PR TITLE
Refatoração de bloqueio de bots

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ ruby '2.6.6'
 gem 'bootsnap', '>= 1.4.2', require: false
 gem 'cpf_cnpj'
 gem 'devise'
+gem 'draper'
 gem 'jbuilder', '~> 2.7'
 gem 'puma', '~> 4.1'
 gem 'rails', '~> 6.0.3', '>= 6.0.3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,10 @@ GEM
       globalid (>= 0.3.6)
     activemodel (6.0.3.2)
       activesupport (= 6.0.3.2)
+    activemodel-serializers-xml (1.0.2)
+      activemodel (> 5.x)
+      activesupport (> 5.x)
+      builder (~> 3.1)
     activerecord (6.0.3.2)
       activemodel (= 6.0.3.2)
       activesupport (= 6.0.3.2)
@@ -92,6 +96,12 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.3)
     docile (1.3.2)
+    draper (4.0.1)
+      actionpack (>= 5.0)
+      activemodel (>= 5.0)
+      activemodel-serializers-xml (>= 1.0)
+      activesupport (>= 5.0)
+      request_store (>= 1.0)
     erubi (1.9.0)
     factory_bot (6.0.2)
       activesupport (>= 5.0.0)
@@ -174,6 +184,8 @@ GEM
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     regexp_parser (1.7.0)
+    request_store (1.5.0)
+      rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -269,6 +281,7 @@ DEPENDENCIES
   capybara
   cpf_cnpj
   devise
+  draper
   factory_bot_rails
   faker!
   jbuilder (~> 2.7)

--- a/app/controllers/block_bots_controller.rb
+++ b/app/controllers/block_bots_controller.rb
@@ -1,24 +1,14 @@
 class BlockBotsController < ApplicationController
   def create
     @bot = Bot.find(params[:bot_id])
-    @bot.awaiting!
-    @block_bot = BlockBot.create!(bot_id: @bot.id, user: current_user)
+    BlockBotCreator.new(@bot, current_user).call
     redirect_to @bot
   end
 
   def confirm
     @bot = Bot.find(params[:bot_id])
-    @block_bot = BlockBot.find_by(params[@bot.id])
-    @bot.blocked!
-    check_company_block
-    @block_bot.update(user: current_user)
-    redirect_to @bot
-  end
-
-  private
-
-  def check_company_block
-    @bot.company.verify_and_block!
+    BlockBotCreator.new(@bot, current_user).call
     flash[:notice] = 'Empresa bloqueada' if @bot.company.blocked?
+    redirect_to @bot
   end
 end

--- a/app/controllers/bots_controller.rb
+++ b/app/controllers/bots_controller.rb
@@ -4,7 +4,7 @@ class BotsController < ApplicationController
   end
 
   def show
-    @bot = Bot.find(params[:id])
+    @bot = Bot.find(params[:id]).decorate
     @block_bot = BlockBot.find_by(params[:bot_id])
   end
 end

--- a/app/decorators/bot_decorator.rb
+++ b/app/decorators/bot_decorator.rb
@@ -1,0 +1,27 @@
+class BotDecorator < Draper::Decorator
+  include Draper::LazyHelpers
+  delegate_all
+
+  def block_bot_link
+    return initial_block_link if active?
+    return confirm_block_link if awaiting?
+
+    ''
+  end
+
+  private
+
+  def initial_block_link
+    link_to 'Bloquear', bot_block_bots_path(self), method: :post
+  end
+
+  def confirm_block_link
+    if current_user != block_bots.first.user
+      return link_to 'Confirmar bloqueio',
+                     confirm_bot_block_bot_path(self),
+                     method: :post
+    end
+
+    'Aguardando confirmação de bloqueio'
+  end
+end

--- a/app/models/bot.rb
+++ b/app/models/bot.rb
@@ -1,7 +1,7 @@
 class Bot < ApplicationRecord
   belongs_to :company
   belongs_to :purchase
-  has_one :block_bot, dependent: :destroy
+  has_many :block_bots, dependent: :destroy
   enum status: { active: 0, awaiting: 2, canceled: 5, blocked: 10 }
   has_many :chats, class_name: 'BotChat', dependent: :restrict_with_error
 

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -9,12 +9,6 @@ class Company < ApplicationRecord
 
   before_create :generate_token
 
-  def verify_and_block!
-    return unless more_than_one_block_bot?
-
-    block!
-  end
-
   def block!
     update(blocked: true)
     bots.update(status: :blocked)
@@ -33,13 +27,5 @@ class Company < ApplicationRecord
       token = SecureRandom.alphanumeric(6).upcase
       break token unless Company.exists?(token: token)
     end
-  end
-
-  def number_of_block_bots
-    block_bots.where(updated_at: (Time.zone.now - 30.days)..Time.zone.now).count
-  end
-
-  def more_than_one_block_bot?
-    number_of_block_bots > 1
   end
 end

--- a/app/services/block_bot_creator.rb
+++ b/app/services/block_bot_creator.rb
@@ -1,0 +1,44 @@
+class BlockBotCreator
+  attr_reader :bot, :user
+
+  NUMBER_OF_BLOCK_TO_BLOCK_COMPANY = 4
+
+  def initialize(bot, user)
+    @bot = bot
+    @user = user
+  end
+
+  def call
+    return if bot.canceled? || bot.blocked?
+
+    create_bot_block
+    verify_block
+    verify_company_block
+  end
+
+  private
+
+  def verify_block
+    return bot.awaiting! if bot.active?
+
+    bot.blocked!
+  end
+
+  def create_bot_block
+    BlockBot.create!(bot: bot, user: user)
+  end
+
+  def verify_company_block
+    return unless number_of_block_bots >= NUMBER_OF_BLOCK_TO_BLOCK_COMPANY
+
+    bot.company.block!
+  end
+
+  def number_of_block_bots
+    bot
+      .company
+      .block_bots
+      .where(updated_at: (Time.zone.now - 30.days)..Time.zone.now)
+      .count
+  end
+end

--- a/app/views/bots/show.html.erb
+++ b/app/views/bots/show.html.erb
@@ -6,13 +6,5 @@
   <dd><%= @bot.token %></dd>
   <dt>Status:</dt>
   <dd><%= Bot.human_attribute_name("status.#{@bot.status}") %></dd>
-  <% if @bot.active? %>
-    <p><%= link_to 'Bloquear', bot_block_bots_path(@bot), method: :post %></p>
-  <% elsif @bot.awaiting? %>
-      <% if @block_bot.user != current_user %>
-        <p><%= link_to 'Confirmar bloqueio', confirm_bot_block_bot_path(@bot), method: :post %></p>
-      <% else %>
-        <p>Aguardando confirmação de bloqueio</p>
-      <% end %>
-  <% end %>
+  <p><%= @bot.block_bot_link %></p>
 </dl>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,6 +12,15 @@
 
 ActiveRecord::Schema.define(version: 2020_07_12_215641) do
 
+  create_table "block_bots", force: :cascade do |t|
+    t.integer "bot_id", null: false
+    t.integer "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["bot_id"], name: "index_block_bots_on_bot_id"
+    t.index ["user_id"], name: "index_block_bots_on_user_id"
+  end
+
   create_table "bot_chats", force: :cascade do |t|
     t.datetime "start_time"
     t.datetime "end_time"
@@ -111,6 +120,8 @@ ActiveRecord::Schema.define(version: 2020_07_12_215641) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "block_bots", "bots"
+  add_foreign_key "block_bots", "users"
   add_foreign_key "bot_chats", "bots"
   add_foreign_key "bots", "companies"
   add_foreign_key "bots", "purchases"

--- a/spec/integration/bot/user_block_bot_spec.rb
+++ b/spec/integration/bot/user_block_bot_spec.rb
@@ -55,7 +55,9 @@ feature 'User block bot' do
     bot3 = create(:bot, company: company2)
 
     create(:block_bot, bot: bot3, created_at: Time.zone.today - 20, updated_at: Time.zone.today - 18)
+    create(:block_bot, bot: bot3, created_at: Time.zone.today - 20, updated_at: Time.zone.today - 18)
 
+    create(:block_bot, bot: bot2, created_at: Time.zone.today - 20, updated_at: Time.zone.today - 18)
     create(:block_bot, bot: bot2, created_at: Time.zone.today - 20, updated_at: Time.zone.today - 18)
 
     login_as user1, scope: :user


### PR DESCRIPTION
## Motivação

As funcionalidades de bloquear bots e clausulas eram confusas e estavam muito na view.

## Solução proposta

Extrair as regras dos links para um ViewModel usando [draper](https://github.com/drapergem/draper) para facilitar mostrar as regras na view.

Após a extração a criação de bloqueios foi extraída para um serviço para facilitar a verificação das regras

## Comentários

A regra mudou um pouco agora todo bloqueio e confirmação ganham um model `BlockBot` para saber quem executou essa ação.

Não ficou tão boa assim a regra mas foi uma possibilidade que não mexe tanto na modelagem